### PR TITLE
Changed the heading buttons in lite mode to say "(Refresh) (Search) (…

### DIFF
--- a/forum.php
+++ b/forum.php
@@ -478,7 +478,8 @@ Type:
 
   // add return to full mode and refresh link
   print "(<a href='forum.php'>Refresh</a>)\n";
-  print "(<a href='" . $locations['forum'] . "?display_mode=2'>Return to Full Mode</a>)\n";
+  print "(<a href='<?=$locations['search']?>'>Search</a>)\n";
+  print "(<a href='" . $locations['forum'] . "?display_mode=0'>Return to Full Mode</a>)\n";
 
   // Check for existing $datfile.lock
   if (file_exists($locations['datfile'] . ".lock")) {


### PR DESCRIPTION
…Return to Full Mode)"

One the main reasons I have to leave lite-mode is to search, so it just makes sense to surface a
Search link at the top of lite-mode.

Also, I changed (Return to Full Mode) to use display_mode=0 and not 2.  Display mode 2 is
basically useless and it doesn't make sense to link to it.
- forum.php:
