### PR TITLE
Adding support for tiktok embeds, fixing FB and Instagram.

### DIFF
--- a/forum.php
+++ b/forum.php
@@ -427,21 +427,36 @@ Type:
 			print 'Alt: ' . $json->alt . '<br />';
 		}
 	  }	elseif (preg_match('/https?:\/\/.+facebook\.com\/.+/',  $link['link_url'])) {
-		$ch = curl_init();
-		$ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.16 (KHTML, like Gecko) \ Chrome/24.0.1304.0 Safari/537.16';
-		curl_setopt($ch, CURLOPT_USERAGENT, $ua);	
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_URL,('https://www.facebook.com/plugins/post/oembed.json/?url=' . urlencode($link['link_url'])));
-		$result=curl_exec($ch);
-		curl_close($ch);
-		$json = json_decode($result);
-		if (isset($json))
-		{
-			print $json->html;
-			print '<br />';
-		}
+      $apiurl = 'https://graph.facebook.com/oembed_page?url=';
+      //if the post type, we need to change the API URL
+      if(preg_match('/https?:\/\/.+facebook\.com\/(?:.+)?(?:posts|activity|photo|permalink|media|questions|notes)/',  $link['link_url']))
+      {
+        $apiurl = 'https://graph.facebook.com/oembed_post?url='
+      }
+      //if video post type, we need to change the API URL
+      if(preg_match('/https?:\/\/.+facebook\.com\/(?:.+)?(?:video)/',  $link['link_url']))
+      {
+        $apiurl = 'https://graph.facebook.com/oembed_video?url='
+      }
+
+      // /oembed_video?url={url}&access_token={access-token}
+      $ch = curl_init();
+		  $ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.16 (KHTML, like Gecko) \ Chrome/24.0.1304.0 Safari/537.16';
+      $authorization = 'Authorization: Bearer AppID|ClientToken';
+      curl_setopt($ch, CURLOPT_HTTPHEADER, array($authorization));
+      curl_setopt($ch, CURLOPT_USERAGENT, $ua);	
+		  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		  curl_setopt($ch, CURLOPT_URL,($apiurl . urlencode($link['link_url'])));
+		  $result=curl_exec($ch);
+		  curl_close($ch);
+		  $json = json_decode($result);
+		  if (isset($json))
+		  {
+			  print $json->html;
+			  print '<br />';
+		  }
     }
     elseif (preg_match('/https?:\/\/(?:www\.)(?:tiktok.com\/@.*)/',  $link['link_url'])) {
       $ch = curl_init();

--- a/forum.php
+++ b/forum.php
@@ -440,7 +440,25 @@ Type:
 			print $json->html;
 			print '<br />';
 		}
-	  }
+    }
+    elseif (preg_match('/https?:\/\/(?:www\.)(?:tiktok.com\/@.*)/',  $link['link_url'])) {
+      $ch = curl_init();
+      $ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.16 (KHTML, like Gecko) \ Chrome/24.0.1304.0 Safari/537.16';
+      curl_setopt($ch, CURLOPT_USERAGENT, $ua);	
+      curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+      curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+      curl_setopt($ch, CURLOPT_URL,('https://www.tiktok.com/oembed?url=' . urlencode($link['link_url'])));
+      $result=curl_exec($ch);
+      curl_close($ch);
+      $json = json_decode($result);
+      if (isset($json))
+      {
+        print $json->html;
+        print '<br />';
+      }
+    }
+
 	    print "<a href='" . preg_replace('/\'/', '&#039;', $link['link_url']) . "' target='" . $post['id'] . "." . $_GET['t'] . "'>";
 	    if (strlen($link['link_title']) > 0)
 	      print $link['link_title'];

--- a/forum.php
+++ b/forum.php
@@ -394,9 +394,11 @@ Type:
           print $json->html;
           print '<br />';
         }
-      } elseif (preg_match('/(https?:\/\/)(www.)?((instagram.com(\/.+)*\/p\/)|(instagr.am\/p\/))/', $link['link_url'])) {
-        $apiurl = 'https://api.instagram.com/oembed?url=';
+      } elseif (preg_match('/(?:https?:\/\/)(?:www.)?(?:(?:instagram.com(?:\/.+)*\/(?:p|(?:tv))\/)|(?:instagr.am\/p\/))/', $link['link_url'])) {
+        $apiurl = 'https://graph.facebook.com/instagram_oembed?url=';
         $ch = curl_init();
+        $authorization = 'Authorization: Bearer AppID|ClientToken';
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array($authorization));
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);

--- a/forum.php
+++ b/forum.php
@@ -438,8 +438,6 @@ Type:
       {
         $apiurl = 'https://graph.facebook.com/oembed_video?url='
       }
-
-      // /oembed_video?url={url}&access_token={access-token}
       $ch = curl_init();
 		  $ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.16 (KHTML, like Gecko) \ Chrome/24.0.1304.0 Safari/537.16';
       $authorization = 'Authorization: Bearer AppID|ClientToken';


### PR DESCRIPTION
well, title says it all.

Copied the code from above and just replaced the regex and oembed URL for TikTok.

FB/Instagram need an app ID and client token, see the change for where to place them in the php file.

FB also has different URLs by type, so it is more complicated.